### PR TITLE
feat: support device history retrieval via UI and MQTT

### DIFF
--- a/springboot/fastbee-common/src/main/java/com/fastbee/common/enums/TopicType.java
+++ b/springboot/fastbee-common/src/main/java/com/fastbee/common/enums/TopicType.java
@@ -35,6 +35,7 @@ public enum TopicType {
     STATUS_POST(1,11,"/status/post","发布状态"),
     NTP_GET(1,15,"/ntp/get","发布时钟同步"),
     INFO_GET(1,18,"/info/get","发布设备信息"),
+    HISTORY_GET(1,26,"/history/get","发布历史数据"),
 
 
     /*** 视频监控设备转协议发布 ***/
@@ -52,7 +53,10 @@ public enum TopicType {
     PROPERTY_GET_SIMULATE(4,23,"/property/get/simulate" ,"发布属性读取"),
     PROPERTY_SET_SIMULATE(4,13, "/property/set/simulate","发布属性写入"),
     WS_SERVICE_INVOKE_SIMULATE(2,24,"/ws/post/simulate", "模拟设备WS推送"),
-    PROPERTY_POST_SIMULATE(2,25,"/property/simulate/post", "订阅属性");
+    PROPERTY_POST_SIMULATE(2,25,"/property/simulate/post", "订阅属性"),
+
+    /*** 历史数据 ***/
+    HISTORY_POST(0,27,"/history/post","订阅历史数据请求");
 
     Integer type;
     Integer order;

--- a/springboot/fastbee-gateway/fastbee-mq/src/main/java/com/fastbee/mq/service/IMqttMessagePublish.java
+++ b/springboot/fastbee-gateway/fastbee-mq/src/main/java/com/fastbee/mq/service/IMqttMessagePublish.java
@@ -9,6 +9,7 @@ import com.fastbee.common.core.thingsModel.ThingsModelSimpleItem;
 import com.fastbee.common.enums.DeviceStatus;
 import com.fastbee.common.enums.TopicType;
 import com.fastbee.iot.domain.Device;
+import com.fastbee.iot.model.HistoryModel;
 import com.fastbee.mq.model.ReportDataBo;
 
 import java.util.List;
@@ -74,6 +75,18 @@ public interface IMqttMessagePublish {
      * @return 设备
      */
     public Device deviceSynchronization(String deviceNumber);
+
+    /**
+     * 推送历史数据
+     *
+     * @param productId   产品ID
+     * @param deviceNum   设备编号
+     * @param identity    物模型标识
+     * @param beginTime   开始时间
+     * @param endTime     结束时间
+     * @param historyList 历史数据集合
+     */
+    void publishHistory(Long productId, String deviceNum, String identity, String beginTime, String endTime, List<HistoryModel> historyList);
 
     /**
      * 推送设备状态

--- a/springboot/fastbee-gateway/fastbee-mq/src/main/java/com/fastbee/mq/service/impl/DeviceOtherMsgHandler.java
+++ b/springboot/fastbee-gateway/fastbee-mq/src/main/java/com/fastbee/mq/service/impl/DeviceOtherMsgHandler.java
@@ -1,7 +1,14 @@
 package com.fastbee.mq.service.impl;
 
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
 import com.fastbee.common.core.mq.DeviceReportBo;
+import com.fastbee.common.utils.DateUtils;
+import com.fastbee.common.utils.StringUtils;
 import com.fastbee.common.utils.gateway.mq.TopicsUtils;
+import com.fastbee.iot.domain.DeviceLog;
+import com.fastbee.iot.model.HistoryModel;
+import com.fastbee.iot.service.IDeviceLogService;
 import com.fastbee.mq.model.ReportDataBo;
 import com.fastbee.mq.service.IDataHandler;
 import com.fastbee.mq.service.IMqttMessagePublish;
@@ -24,6 +31,8 @@ public class DeviceOtherMsgHandler {
     private IDataHandler dataHandler;
     @Resource
     private IMqttMessagePublish messagePublish;
+    @Resource
+    private IDeviceLogService deviceLogService;
 
     /**
      * 非属性消息消息处理入口
@@ -75,6 +84,12 @@ public class DeviceOtherMsgHandler {
                     messagePublish.sendFunctionMessage(bo);
                 }
                 break;
+            case "history":
+                type = topicsUtils.parseTopicName4(bo.getTopicName());
+                if ("post".equals(type)) {
+                    handleHistoryRequest(data);
+                }
+                break;
         }
     }
 
@@ -89,6 +104,49 @@ public class DeviceOtherMsgHandler {
         dataBo.setSerialNumber(bo.getSerialNumber());
         dataBo.setRuleEngine(false);
         return dataBo;
+    }
+
+    private void handleHistoryRequest(ReportDataBo data) {
+        if (StringUtils.isEmpty(data.getMessage())) {
+            return;
+        }
+        JSONObject jsonObject = JSON.parseObject(data.getMessage());
+        if (jsonObject == null) {
+            return;
+        }
+        String identity = jsonObject.getString("identity");
+        if (StringUtils.isEmpty(identity)) {
+            return;
+        }
+        String serialNumber = StringUtils.defaultIfEmpty(jsonObject.getString("serialNumber"), data.getSerialNumber());
+        String endTime = jsonObject.getString("endTime");
+        if (StringUtils.isEmpty(endTime)) {
+            endTime = DateUtils.parseDateToStr(DateUtils.YYYY_MM_DD_HH_MM_SS, DateUtils.getNowDate());
+        }
+        String beginTime = jsonObject.getString("startTime");
+        if (StringUtils.isEmpty(beginTime)) {
+            beginTime = DateUtils.parseDateToStr(DateUtils.YYYY_MM_DD_HH_MM_SS,
+                    DateUtils.addDays(DateUtils.dateTime(DateUtils.YYYY_MM_DD_HH_MM_SS, endTime), -1));
+        }
+        DeviceLog query = new DeviceLog();
+        query.setSerialNumber(serialNumber);
+        query.setIdentity(identity);
+        query.setBeginTime(beginTime);
+        query.setEndTime(endTime);
+        query.setIsHistory(1);
+        query.setLogType(jsonObject.getInteger("logType") != null ? jsonObject.getInteger("logType") : 1);
+        Integer isMonitor = jsonObject.getInteger("isMonitor");
+        query.setIsMonitor(isMonitor != null ? isMonitor : 0);
+        Integer limit = jsonObject.getInteger("limit");
+        if (limit != null && limit > 0) {
+            query.setTotal(limit);
+        }
+        Integer slaveId = jsonObject.getInteger("slaveId");
+        if (slaveId != null) {
+            query.setSlaveId(slaveId);
+        }
+        java.util.List<HistoryModel> historyList = deviceLogService.selectHistoryList(query);
+        messagePublish.publishHistory(data.getProductId(), serialNumber, identity, beginTime, endTime, historyList);
     }
 
 }

--- a/springboot/fastbee-open-api/src/main/java/com/fastbee/data/controller/DeviceLogController.java
+++ b/springboot/fastbee-open-api/src/main/java/com/fastbee/data/controller/DeviceLogController.java
@@ -3,6 +3,7 @@ package com.fastbee.data.controller;
 import com.fastbee.common.core.controller.BaseController;
 import com.fastbee.common.core.page.TableDataInfo;
 import com.fastbee.iot.domain.DeviceLog;
+import com.fastbee.iot.model.HistoryModel;
 import com.fastbee.iot.model.MonitorModel;
 import com.fastbee.iot.service.IDeviceLogService;
 import io.swagger.annotations.Api;
@@ -49,6 +50,19 @@ public class DeviceLogController extends BaseController
     {
         startPage();
         List<DeviceLog> list = deviceLogService.selectDeviceLogList(deviceLog);
+        return getDataTable(list);
+    }
+
+    /**
+     * 查询设备历史数据
+     */
+    @ApiOperation("查询设备历史数据")
+    @PreAuthorize("@ss.hasPermi('iot:device:list')")
+    @GetMapping("/history")
+    public TableDataInfo history(DeviceLog deviceLog)
+    {
+        startPage();
+        List<HistoryModel> list = deviceLogService.selectHistoryList(deviceLog);
         return getDataTable(list);
     }
 

--- a/springboot/fastbee-server/mqtt-broker/src/main/java/com/fastbee/mqtt/service/impl/MqttMessagePublishImpl.java
+++ b/springboot/fastbee-server/mqtt-broker/src/main/java/com/fastbee/mqtt/service/impl/MqttMessagePublishImpl.java
@@ -26,6 +26,7 @@ import com.fastbee.common.utils.ip.IpUtils;
 import com.fastbee.iot.domain.Device;
 import com.fastbee.iot.domain.FunctionLog;
 import com.fastbee.iot.domain.Product;
+import com.fastbee.iot.model.HistoryModel;
 import com.fastbee.iot.model.NtpModel;
 import com.fastbee.iot.model.ThingsModels.PropertyDto;
 import com.fastbee.iot.ruleEngine.RuleProcess;
@@ -47,7 +48,9 @@ import org.springframework.stereotype.Service;
 
 import jakarta.annotation.Resource;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -327,6 +330,18 @@ public class MqttMessagePublishImpl implements IMqttMessagePublish {
             mqttClient.publish(1, true,  topic, JSON.toJSONString(thingsList));
         }
 
+    }
+
+    @Override
+    public void publishHistory(Long productId, String deviceNum, String identity, String beginTime, String endTime, List<HistoryModel> historyList) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("identity", identity);
+        payload.put("startTime", beginTime);
+        payload.put("endTime", endTime);
+        payload.put("count", historyList == null ? 0 : historyList.size());
+        payload.put("data", historyList);
+        String topic = topicsUtils.buildTopic(productId, deviceNum, TopicType.HISTORY_GET);
+        mqttClient.publish(1, false, topic, JSON.toJSONString(payload));
     }
 
     /**

--- a/springboot/fastbee-service/fastbee-iot-service/src/main/java/com/fastbee/iot/mapper/DeviceLogMapper.java
+++ b/springboot/fastbee-service/fastbee-iot-service/src/main/java/com/fastbee/iot/mapper/DeviceLogMapper.java
@@ -3,6 +3,7 @@ package com.fastbee.iot.mapper;
 import com.fastbee.iot.domain.Device;
 import com.fastbee.iot.domain.DeviceLog;
 import com.fastbee.iot.model.DeviceStatistic;
+import com.fastbee.iot.model.HistoryModel;
 import com.fastbee.iot.model.MonitorModel;
 import org.springframework.stereotype.Repository;
 
@@ -86,5 +87,13 @@ public interface DeviceLogMapper
      * @return 设备日志集合
      */
     public List<DeviceLog> selectDeviceLogList(DeviceLog deviceLog);
+
+    /**
+     * 查询历史数据
+     *
+     * @param deviceLog 查询条件
+     * @return 历史数据集合
+     */
+    List<HistoryModel> selectHistoryList(DeviceLog deviceLog);
 
 }

--- a/springboot/fastbee-service/fastbee-iot-service/src/main/java/com/fastbee/iot/service/IDeviceLogService.java
+++ b/springboot/fastbee-service/fastbee-iot-service/src/main/java/com/fastbee/iot/service/IDeviceLogService.java
@@ -32,4 +32,12 @@ public interface IDeviceLogService
      */
     public List<DeviceLog> selectDeviceLogList(DeviceLog deviceLog);
 
+    /**
+     * 查询设备历史数据
+     *
+     * @param deviceLog 查询条件
+     * @return 历史数据集合
+     */
+    List<HistoryModel> selectHistoryList(DeviceLog deviceLog);
+
 }

--- a/springboot/fastbee-service/fastbee-iot-service/src/main/java/com/fastbee/iot/service/impl/DeviceLogServiceImpl.java
+++ b/springboot/fastbee-service/fastbee-iot-service/src/main/java/com/fastbee/iot/service/impl/DeviceLogServiceImpl.java
@@ -52,4 +52,18 @@ public class DeviceLogServiceImpl implements IDeviceLogService
         }
         return logService.selectDeviceLogList(deviceLog);
     }
+
+    @Override
+    public List<HistoryModel> selectHistoryList(DeviceLog deviceLog) {
+        if (deviceLog.getIsHistory() == null) {
+            deviceLog.setIsHistory(1);
+        }
+        if (deviceLog.getLogType() == null) {
+            deviceLog.setLogType(1);
+        }
+        if (deviceLog.getIsMonitor() == null) {
+            deviceLog.setIsMonitor(0);
+        }
+        return logService.selectHistoryList(deviceLog);
+    }
 }

--- a/springboot/fastbee-service/fastbee-iot-service/src/main/java/com/fastbee/iot/tdengine/service/ILogService.java
+++ b/springboot/fastbee-service/fastbee-iot-service/src/main/java/com/fastbee/iot/tdengine/service/ILogService.java
@@ -34,5 +34,8 @@ public interface ILogService {
     /** 查询物模型日志列表 **/
     List<DeviceLog> selectDeviceLogList(DeviceLog deviceLog);
 
+    /** 查询历史数据 **/
+    List<HistoryModel> selectHistoryList(DeviceLog deviceLog);
+
 
 }

--- a/springboot/fastbee-service/fastbee-iot-service/src/main/java/com/fastbee/iot/tdengine/service/impl/MySqlLogServiceImpl.java
+++ b/springboot/fastbee-service/fastbee-iot-service/src/main/java/com/fastbee/iot/tdengine/service/impl/MySqlLogServiceImpl.java
@@ -60,4 +60,9 @@ public class MySqlLogServiceImpl implements ILogService {
     public List<DeviceLog> selectDeviceLogList(DeviceLog deviceLog) {
         return deviceLogMapper.selectDeviceLogList(deviceLog);
     }
+
+    @Override
+    public List<HistoryModel> selectHistoryList(DeviceLog deviceLog) {
+        return deviceLogMapper.selectHistoryList(deviceLog);
+    }
 }

--- a/springboot/fastbee-service/fastbee-iot-service/src/main/resources/mapper/iot/DeviceLogMapper.xml
+++ b/springboot/fastbee-service/fastbee-iot-service/src/main/resources/mapper/iot/DeviceLogMapper.xml
@@ -51,6 +51,21 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         limit #{total}
     </select>
 
+    <select id="selectHistoryList" parameterType="com.fastbee.iot.domain.DeviceLog" resultMap="HistoryResult">
+        select log_value, create_time, identify from iot_device_log
+        <where>
+            <if test="deviceId != null and deviceId !=0"> and device_id = #{deviceId}</if>
+            <if test="serialNumber != null and serialNumber !=''"> and serial_number = #{serialNumber}</if>
+            <if test="identity != null and identity != ''"> and identify = #{identity}</if>
+            <if test="logType != null"> and log_type = #{logType}</if>
+            <if test="isMonitor != null"> and is_monitor = #{isMonitor}</if>
+            <if test="isHistory != null"> and is_history = #{isHistory}</if>
+            <if test="beginTime != null and beginTime != '' and endTime != null and endTime != ''"> and create_time between #{beginTime} and #{endTime}</if>
+        </where>
+        order by create_time asc
+        <if test="total != null and total != 0">limit #{total}</if>
+    </select>
+
 
     <select id="selectDeviceLogByLogId" parameterType="Long" resultMap="DeviceLogResult">
         <include refid="selectDeviceLogVo"/>

--- a/vue/src/api/iot/deviceHistory.js
+++ b/vue/src/api/iot/deviceHistory.js
@@ -1,0 +1,9 @@
+import request from '@/utils/request'
+
+export function listDeviceHistory(query) {
+  return request({
+    url: '/iot/deviceLog/history',
+    method: 'get',
+    params: query,
+  })
+}

--- a/vue/src/views/iot/device/device-edit.vue
+++ b/vue/src/views/iot/device/device-edit.vue
@@ -147,6 +147,11 @@
                 <device-func ref="deviceFuncLog" :device="form" />
             </el-tab-pane>
 
+            <el-tab-pane name="deviceHistory" key="7" v-if="form.deviceType !== 3 && form.deviceId !=0 && hasShrarePerm('log')" lazy>
+                <span slot="label">历史数据</span>
+                <device-history ref="deviceHistory" :device="form" />
+            </el-tab-pane>
+
             <!-- 用于设置间距 -->
             <el-tab-pane disabled>
                 <span slot="label">
@@ -228,6 +233,7 @@ import runningStatus from './running-status';
 
 import deviceTimer from './device-timer';
 import DeviceFunc from './device-functionlog';
+import deviceHistory from './device-history';
 import vueQr from 'vue-qr';
 import { loadBMap } from '@/utils/map.js';
 import { deviceSynchronization, getDevice, addDevice, updateDevice, generatorDeviceNum, getMqttConnect } from '@/api/iot/device';
@@ -245,6 +251,7 @@ export default {
         DeviceFunc,
         deviceLog,
         deviceUser,
+        deviceHistory,
         runningStatus,
         productList,
         deviceTimer,
@@ -548,6 +555,8 @@ export default {
                         this.$refs.deviceSub.gateway.gwDeviceId = this.form.deviceId;
                         this.$refs.deviceSub.getList();
                     }
+                } else if (panel.name === 'deviceHistory') {
+                    this.$refs.deviceHistory && this.$refs.deviceHistory.getList();
                 }
             });
             if (this.form.deviceType !== 3) {

--- a/vue/src/views/iot/device/device-history.vue
+++ b/vue/src/views/iot/device/device-history.vue
@@ -1,0 +1,232 @@
+<template>
+  <div style="padding-left: 20px">
+    <el-form :inline="true" label-width="80px" style="margin-bottom: 10px">
+      <el-form-item label="历史属性">
+        <el-select
+          v-model="queryParams.identity"
+          placeholder="请选择历史属性"
+          clearable
+          filterable
+          size="small"
+          style="width: 220px"
+          @change="onIdentityChange"
+        >
+          <el-option
+            v-for="item in historyOptions"
+            :key="item.value"
+            :label="item.label"
+            :value="item.value"
+          />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="时间范围">
+        <el-date-picker
+          v-model="dateRange"
+          type="datetimerange"
+          size="small"
+          style="width: 320px"
+          value-format="yyyy-MM-dd HH:mm:ss"
+          range-separator="至"
+          start-placeholder="开始时间"
+          end-placeholder="结束时间"
+          :default-time="['00:00:00', '23:59:59']"
+        />
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" icon="el-icon-search" size="mini" @click="handleQuery">查询</el-button>
+        <el-button icon="el-icon-refresh" size="mini" @click="handleReset">重置</el-button>
+      </el-form-item>
+    </el-form>
+    <el-alert
+      v-if="!historyOptions.length"
+      type="info"
+      :closable="false"
+      title="当前设备暂无开启历史存储的属性。"
+      show-icon
+      style="margin-bottom: 10px"
+    />
+    <el-table v-loading="loading" :data="historyList" size="mini" style="width: 100%">
+      <el-table-column label="时间" prop="time" width="180">
+        <template slot-scope="scope">
+          {{ parseTime(scope.row.time, '{y}-{m}-{d} {h}:{i}:{s}') }}
+        </template>
+      </el-table-column>
+      <el-table-column label="数值" prop="value">
+        <template slot-scope="scope">
+          <span>{{ scope.row.value }}</span>
+          <span v-if="currentUnit" style="color: #909399; margin-left: 4px">{{ currentUnit }}</span>
+        </template>
+      </el-table-column>
+    </el-table>
+    <div style="height: 40px">
+      <pagination
+        v-show="total > 0"
+        :total="total"
+        :page.sync="queryParams.pageNum"
+        :limit.sync="queryParams.pageSize"
+        @pagination="getList"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { listDeviceHistory } from '@/api/iot/deviceHistory'
+
+export default {
+  name: 'DeviceHistory',
+  props: {
+    device: {
+      type: Object,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      loading: false,
+      deviceInfo: {},
+      historyOptions: [],
+      historyMeta: {},
+      currentUnit: '',
+      dateRange: [],
+      historyList: [],
+      total: 0,
+      queryParams: {
+        pageNum: 1,
+        pageSize: 20,
+        serialNumber: null,
+        identity: null,
+      },
+    }
+  },
+  watch: {
+    device: {
+      handler(newVal) {
+        this.deviceInfo = newVal || {}
+        if (this.deviceInfo && this.deviceInfo.deviceId) {
+          this.queryParams.serialNumber = this.deviceInfo.serialNumber
+          this.resetDateRange()
+          this.buildHistoryOptions()
+          this.queryParams.pageNum = 1
+          this.getList()
+        } else {
+          this.queryParams.serialNumber = null
+          this.historyOptions = []
+          this.historyMeta = {}
+          this.currentUnit = ''
+          this.historyList = []
+          this.total = 0
+        }
+      },
+      deep: true,
+      immediate: true,
+    },
+  },
+  methods: {
+    buildHistoryOptions() {
+      this.historyOptions = []
+      this.historyMeta = {}
+      const cache = this.deviceInfo && this.deviceInfo.cacheThingsModel ? this.deviceInfo.cacheThingsModel : {}
+      this.collectHistoryItems(cache.properties || [], '')
+      if (!this.historyOptions.length) {
+        this.queryParams.identity = null
+        this.currentUnit = ''
+        return
+      }
+      if (!this.historyOptions.find((item) => item.value === this.queryParams.identity)) {
+        this.queryParams.identity = this.historyOptions[0].value
+      }
+      this.currentUnit = this.historyMeta[this.queryParams.identity]
+        ? this.historyMeta[this.queryParams.identity].unit
+        : ''
+    },
+    collectHistoryItems(items, prefix) {
+      if (!Array.isArray(items)) {
+        return
+      }
+      items.forEach((item, index) => {
+        const identity = item.id || item.identifier
+        const unit = item.datatype && item.datatype.unit ? item.datatype.unit : ''
+        const label = prefix ? `${prefix} / ${item.name}` : item.name
+        if (item.isHistory === 1 && identity) {
+          if (!this.historyMeta[identity]) {
+            this.historyOptions.push({ value: identity, label, unit })
+          }
+          this.historyMeta[identity] = { label, unit }
+        }
+        if (item.datatype) {
+          if (item.datatype.type === 'object' && Array.isArray(item.datatype.params)) {
+            this.collectHistoryItems(item.datatype.params, label)
+          } else if (item.datatype.type === 'array') {
+            if (Array.isArray(item.datatype.arrayParams)) {
+              item.datatype.arrayParams.forEach((group, idx) => {
+                const groupLabel = `${item.name}[${idx + 1}]`
+                const nestedPrefix = prefix ? `${prefix} / ${groupLabel}` : groupLabel
+                this.collectHistoryItems(group, nestedPrefix)
+              })
+            } else if (Array.isArray(item.datatype.arrayModel)) {
+              item.datatype.arrayModel.forEach((model, idx) => {
+                const modelIdentity = model.id || model.identifier
+                const shouldInclude = model.isHistory === 1 || item.isHistory === 1
+                if (shouldInclude && modelIdentity) {
+                  const modelLabel = prefix
+                    ? `${prefix} / ${item.name}[${idx + 1}]`
+                    : `${item.name}[${idx + 1}]`
+                  if (!this.historyMeta[modelIdentity]) {
+                    this.historyOptions.push({ value: modelIdentity, label: modelLabel, unit })
+                  }
+                  this.historyMeta[modelIdentity] = { label: modelLabel, unit }
+                }
+              })
+            }
+          }
+        }
+      })
+    },
+    resetDateRange() {
+      const end = new Date()
+      const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
+      this.dateRange = [this.formatDate(start), this.formatDate(end)]
+    },
+    formatDate(date) {
+      return this.parseTime(date, '{y}-{m}-{d} {h}:{i}:{s}')
+    },
+    handleQuery() {
+      this.queryParams.pageNum = 1
+      this.getList()
+    },
+    handleReset() {
+      this.resetDateRange()
+      this.buildHistoryOptions()
+      this.queryParams.pageNum = 1
+      this.getList()
+    },
+    onIdentityChange(val) {
+      this.currentUnit = this.historyMeta[val] ? this.historyMeta[val].unit : ''
+      this.handleQuery()
+    },
+    getList() {
+      if (!this.queryParams.serialNumber || !this.queryParams.identity) {
+        this.historyList = []
+        this.total = 0
+        return
+      }
+      const params = {
+        ...this.queryParams,
+        beginTime: this.dateRange && this.dateRange.length ? this.dateRange[0] : null,
+        endTime: this.dateRange && this.dateRange.length ? this.dateRange[1] : null,
+      }
+      this.loading = true
+      listDeviceHistory(params)
+        .then((response) => {
+          this.historyList = response.rows || []
+          this.total = response.total || 0
+          this.loading = false
+        })
+        .catch(() => {
+          this.loading = false
+        })
+    },
+  },
+}
+</script>


### PR DESCRIPTION
## Summary
- add backend history query support and expose REST API
- extend MQTT pipeline with history request handling and publish payloads
- add Vue history view and client API for selecting stored properties

## Testing
- `mvn -pl fastbee-open-api,fastbee-gateway/fastbee-mq,fastbee-server/mqtt-broker,fastbee-service/fastbee-iot-service -am -DskipTests package` *(fails: cannot resolve maven.aliyun.com)*

------
https://chatgpt.com/codex/tasks/task_e_68d57b1ac14c832bacaef74c2da9e85d